### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM gliderlabs/alpine:3.2
+ENTRYPOINT ["/bin/go_server_linux_amd64"]
+
+COPY bin/go_server_linux_amd64 /bin
+COPY public /public

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+## Run in Docker
+
+First, install [docker toolbox](https://www.docker.com/docker-toolbox)
+
+Then, type the commands below to run docker
+
+```
+$ eval $(docker-machine env default)
+$ docker build -t docker_go .
+$ docker run -d -p 80:8080 --name go_server docker_go
+```
+
+From now, you can access `docker-machine ip default` in browser
+
+You can remove docker go_server by
+
+```
+$ docker rm -f go_server
+```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Go Server
+
+Simple server implementation by golang
+
 ## Run in Docker
 
 First, install [docker toolbox](https://www.docker.com/docker-toolbox)


### PR DESCRIPTION
Dockerのサンプルとして使うためDockerファイルを用意

```
eval $(docker-machine env default)
docker build -t docker_go .
docker run -d -p 80:8080 --name go_server docker_go
```

までしたうえで、

```
docker-machine ip default
```

で出てくるIPにアクセスする。
